### PR TITLE
Added link to the issues tracker on Community page

### DIFF
--- a/pages/community.rst
+++ b/pages/community.rst
@@ -38,12 +38,13 @@ Issue Tracker
 =============
 If you find a bug in bpython or have a suggestion for a new feature, please 
 first make sure you're using the latest development release (see download_ 
-page) and if it hasn't been fixed/added, go here and open a new issue.
+page) and if it hasn't been fixed/added, go here_ and open a new issue.
 
 Wiki
 ====
 Want to set up a Wiki for us? Email me to let me know where it is and the link will go here.
 
+.. _here: https://github.com/bpython/bpython/issues
 .. _download: /downloads
 .. _mailing list: https://groups.google.com/forum/#!forum/bpython
 .. _bpythonrepl: http://twitter.com/bpythonrepl


### PR DESCRIPTION
The Community page had a non-existent link to the issue tracker, I added the link.
