### PR TITLE
Update alternatives.rst to fix a link

### DIFF
--- a/pages/alternatives.rst
+++ b/pages/alternatives.rst
@@ -12,6 +12,6 @@ If you know of any others please let us know. And if you're the author of any of
   * IPython_
   * `Python Prompt Toolkit`_
 
-.. _IPython: http://python.scipy.com/moin/
+.. _IPython: http://ipython.org
 .. _DreamPie: http://dreampie.sourceforge.net/
 .. _Python Prompt Toolkit: https://github.com/jonathanslenders/python-prompt-toolkit


### PR DESCRIPTION
The link to IPython has been updated to the current link.
