### PR TITLE
REPL part of Python Prompt Toolkit is now ptpython

### DIFF
--- a/pages/alternatives.rst
+++ b/pages/alternatives.rst
@@ -10,8 +10,8 @@ If you know of any others please let us know. And if you're the author of any of
 
   * DreamPie_
   * IPython_
-  * `Python Prompt Toolkit`_
+  * ptpython_
 
 .. _IPython: http://ipython.org
 .. _DreamPie: http://dreampie.sourceforge.net/
-.. _Python Prompt Toolkit: https://github.com/jonathanslenders/python-prompt-toolkit
+.. _ptpython: https://github.com/jonathanslenders/ptpython


### PR DESCRIPTION
The background for it is mentioned in the [README file](https://github.com/jonathanslenders/python-prompt-toolkit#looking-for-ptpython-the-python-repl) for Python Prompt Toolkit.
