### PR TITLE
Fixing links on homepage to about and screenshot sections.

### DIFF
--- a/pages/homepage.rst
+++ b/pages/homepage.rst
@@ -26,5 +26,5 @@ in New York City and have a great attitude towards the development of both male
 and female programmers - take a look.
 
 .. _Recurse Center: https://www.recurse.com/
-.. _about: /about
-.. _screenshots: /screenshots
+.. _about: /about.html
+.. _screenshots: /screenshots.html


### PR DESCRIPTION
Links on sidebar to `about` and `screenshot` sections worked, but links to those same sections within `homepage.rst` didn't.  It seems said links are missing `.html`, which this PR fixes.